### PR TITLE
Blackparrot mods

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,8 @@
 RISCV ?= $(CURDIR)/toolchain
 PATH := $(RISCV)/bin:$(PATH)
 ISA ?= rv64imafd
-BBL_ISA ?= rv64ia
-ABI ?= lp64
+BBL_ISA ?= rv64imafd
+ABI ?= lp64d
 
 saveterm := $(shell stty -g)
 


### PR DESCRIPTION
@farzamgl
This enables floating point support and is required for the latest Litex-BlackParrot.
https://github.com/bsg-external/riscv-pk/pull/2 should be merged first and the submodule adjusted properly